### PR TITLE
Fix Spectra13 image dither

### DIFF
--- a/firmware/usermods/inkplate/image/dither.h
+++ b/firmware/usermods/inkplate/image/dither.h
@@ -29,7 +29,7 @@
 // per-format scratch-buffer width caps in bmp_draw.c/jpeg_draw_core.h/png_draw_core.h.
 // Must not be padded up for headroom: callers size static/PSRAM scratch buffers
 // directly off this value, and larger sizes have been found tight on real hardware.
-#define INKPLATE_DRAW_MAX_WIDTH 1280
+#define INKPLATE_DRAW_MAX_WIDTH 1600
 
 // Selects which diffusion kernel dither_diffuse_error/dither_diffuse_error_rgb use.
 enum {


### PR DESCRIPTION
- Bump INKPLATE_DRAW_MAX_WIDTH to 1600 to support 13 Spectra's full width.
  WARNING: This appears to be a shared function and there are comments 
  indicating an increase beyond 1280 may cause issues with other inkplates.